### PR TITLE
remove extra slash

### DIFF
--- a/lib/wordnik-bb.js
+++ b/lib/wordnik-bb.js
@@ -166,7 +166,7 @@ exports.init = function(APIKEY) {
       }
       queryString = queryString.substr(1,queryString.length);
 
-      return "http://api.wordnik.com//v4/words.json/randomWord?" + queryString + "&api_key=" + APIKEY;
+      return "http://api.wordnik.com/v4/words.json/randomWord?" + queryString + "&api_key=" + APIKEY;
     },
     getRandomWord: function() {
       return this.fetch({


### PR DESCRIPTION
first off thanks for making a straightforward client unlike this swagger stuff x)

so when I was trying to use random word, it was failing. Seems there is an extra slash in the url. I removed that slash and now it's groovy.

Cheers.